### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -38,15 +38,15 @@ pub struct Block {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Statement {
-	Block(Block),
-	Expression(Expression),
-	If(IfStatement),
-	While(WhileStatement),
-	ClassDeclaration(String),
-	VerbStatement(VerbStatement),
-	VariableDeclaration(VariableDeclaration),
-	PropertyAssignment(PropertyAssignment),
-	StateStatement(StateStatement),
+        Block(Block),
+        Expression(Expression),
+        If(IfStatement),
+        While(WhileStatement),
+        ClassDeclaration(String),
+        Verb(VerbStatement),
+        VariableDeclaration(VariableDeclaration),
+        PropertyAssignment(PropertyAssignment),
+        State(StateStatement),
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,14 +29,12 @@ fn parse_block(pair: Pair<Rule>) -> Block {
 fn parse_statement(pair: Pair<Rule>) -> Option<Statement> {
 	match pair.as_rule() {
 		Rule::block => Some(Statement::Block(parse_block(pair))),
-		Rule::expr_stmt => {
-			let mut inner = pair.into_inner();
-			if let Some(expr_pair) = inner.next() {
-				Some(Statement::Expression(parse_expression(expr_pair)))
-			} else {
-				None
-			}
-		},
+                Rule::expr_stmt => {
+                        let mut inner = pair.into_inner();
+                        inner
+                                .next()
+                                .map(|expr_pair| Statement::Expression(parse_expression(expr_pair)))
+                },
 		Rule::if_stmt => {
 			let mut inner = pair.into_inner();
 			let condition = parse_expression(inner.next()?);
@@ -68,12 +66,12 @@ fn parse_statement(pair: Pair<Rule>) -> Option<Statement> {
 			let name = inner.next()?.as_str().to_string();
 			Some(Statement::ClassDeclaration(name))
 		},
-		Rule::verb_stmt => {
-			let mut inner = pair.into_inner();
-			let name = inner.next()?.as_str().to_string();
-			let body = inner.next().map(parse_block);
-			Some(Statement::VerbStatement(VerbStatement { name, body }))
-		},
+                Rule::verb_stmt => {
+                        let mut inner = pair.into_inner();
+                        let name = inner.next()?.as_str().to_string();
+                        let body = inner.next().map(parse_block);
+                        Some(Statement::Verb(VerbStatement { name, body }))
+                },
 		Rule::var_decl => {
 			let mut inner = pair.into_inner();
 			let var_type = inner.next()?.as_str().to_string();
@@ -106,7 +104,7 @@ fn parse_statement(pair: Pair<Rule>) -> Option<Statement> {
 					}
 				}
 			}
-			Some(Statement::StateStatement(StateStatement { number, assignments }))
+                        Some(Statement::State(StateStatement { number, assignments }))
 		},
 		_ => None,
 	}
@@ -526,14 +524,14 @@ mod tests {
 
 				matches!(obj.body.statements[0], Statement::ClassDeclaration(_));
 
-				if let Statement::VerbStatement(ref verb) = obj.body.statements[1] {
+                                if let Statement::Verb(ref verb) = obj.body.statements[1] {
 					assert_eq!(verb.name, "vOne");
 					assert!(verb.body.is_none());
 				} else {
 					panic!("expected verb statement");
 				}
 
-				if let Statement::VerbStatement(ref verb) = obj.body.statements[2] {
+                                if let Statement::Verb(ref verb) = obj.body.statements[2] {
 					assert_eq!(verb.name, "vTwo");
 					let body = verb.body.as_ref().unwrap();
 					assert_eq!(body.statements.len(), 1);
@@ -623,7 +621,7 @@ mod tests {
 }"#;
 		let ast = parse_ok(src);
 		if let TopLevel::Object(obj) = &ast[0] {
-			if let Statement::StateStatement(state) = &obj.body.statements[0] {
+                        if let Statement::State(state) = &obj.body.statements[0] {
 				assert_eq!(state.number, 0);
 				assert_eq!(state.assignments.len(), 1);
 				assert_eq!(state.assignments[0].0, "open");


### PR DESCRIPTION
## Summary
- rename some Statement enum variants to avoid clippy::enum-variant-names
- simplify `expr_stmt` parsing
- update parser tests for new variant names

## Testing
- `cargo clippy --all-features -- -D warnings`
- `cargo test --all-features`
