### PR TITLE
Add interpreter math tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,7 +303,7 @@ fn parse_primary(pair: Pair<Rule>) -> Primary {
 			let inner_expr = pair.into_inner().next().unwrap();
 			Primary::Parenthesized(Box::new(parse_expression(inner_expr)))
 		},
-		_ => Primary::Number(0), // Fallback
+		_ => Primary::Parenthesized(Box::new(parse_expression(pair))),
 	}
 }
 


### PR DESCRIPTION
## Summary
- improve expression parsing for parenthesized expressions
- allow interpreter to run in non-wasm tests with a stub web interface
- add unit tests for math and variable assignments
- use `Interpreter::new` in tests and tick until scripts finish

## Testing
- `cargo check --all-features`
- `cargo test --all-features`
- `cargo clippy --all-features -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_683d51a1d408832aba198363b604065a