### PR TITLE
Add states array support

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -71,6 +71,9 @@ impl Object {
 						anyhow::bail!("Property '{}' must be a number", prop.name);
 					}
 				},
+				Statement::States(entries) => {
+					obj.states = entries.iter().map(|e| e.image.clone()).collect();
+				},
 				Statement::PropertyAssignment(prop) => {
 					anyhow::bail!("Unsupported property assignment in object definition: {:?}", prop);
 				},
@@ -188,6 +191,7 @@ pub enum Statement {
 	Verb(VerbStatement),
 	VariableDeclaration(VariableDeclaration),
 	PropertyAssignment(PropertyAssignment),
+	States(Vec<StateEntry>),
 	State(StateStatement),
 	ObjectDeclaration(Object),
 	ScriptDeclaration(Script),
@@ -268,6 +272,13 @@ pub enum PropertyValue {
 pub struct StateStatement {
 	pub number: u32,
 	pub assignments: Vec<(String, Primary)>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct StateEntry {
+	pub x: i32,
+	pub y: i32,
+	pub image: String,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ mod preprocessor;
 
 use anyhow::Result;
 use ast::{
-	Block, Class, Expression, FunctionCall, IfStatement, Object, Primary, PropertyAssignment, PropertyValue, Room, Script, Statement, TopLevel,
+	Block, Class, Expression, FunctionCall, IfStatement, Object, Primary, PropertyAssignment, PropertyValue, Room, Script, StateEntry, Statement, TopLevel,
 	VariableDeclaration, VerbStatement, WhileStatement,
 };
 use log::{debug, error, info};
@@ -123,9 +123,22 @@ fn parse_statement(pair: Pair<Rule>) -> Option<Statement> {
 			Some(Statement::ScriptDeclaration(Script { name, body }))
 		},
 		Rule::states_assign => {
-			// For now, skip states_assign parsing since we don't have a complete implementation
-			// This prevents parse errors but doesn't create AST nodes for states
-			None
+			let mut inner = pair.into_inner();
+			if let Some(array_pair) = inner.next() {
+				let mut states = Vec::new();
+				for entry in array_pair.into_inner() {
+					let mut ei = entry.into_inner();
+					let x: i32 = ei.next()?.as_str().parse().ok()?;
+					let y: i32 = ei.next()?.as_str().parse().ok()?;
+					let img_pair = ei.next()?;
+					let raw = img_pair.as_str();
+					let image = raw[1..raw.len() - 1].to_string();
+					states.push(StateEntry { x, y, image });
+				}
+				Some(Statement::States(states))
+			} else {
+				None
+			}
 		},
 		_ => None,
 	}


### PR DESCRIPTION
## Summary
- support `states_assign` in grammar and AST
- map parsed state entries to `ObjectDef.states`

## Testing
- `cargo check --all-features`
- `cargo test --all-features`
- `cargo clippy --all-features -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_683d697d7cb4832ab8fadf402b2e4364