### PR TITLE
Fix WASM build by enabling DomRect

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,8 @@ thiserror = "2.0.12"
 wasm-bindgen-futures = "0.4"
 web-sys      = { version = "0.3", features = ["HtmlImageElement",
                                               "Element", "Document",
-                                              "Window", "MouseEvent", "Response", "console"] }
+                                              "Window", "MouseEvent", "Response", "console",
+                                              "DomRect"] }
 futures = "0.3.31"
 async-recursion = "1.1.1"
 indexmap = "2.9.0"

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -233,7 +233,7 @@ impl WebInterface {
 			*self.current_room_image.borrow_mut() = Some(img.to_string());
 
 			// Load the image to get its natural dimensions
-			let image_element = web_sys::HtmlImageElement::new()?;
+			let image_element = HtmlImageElement::new()?;
 			let scale_x = self.scale_x.clone();
 			let scale_y = self.scale_y.clone();
 			let room_container = self.room_container.clone();


### PR DESCRIPTION
## Summary
- enable `DomRect` on web-sys so `get_bounding_client_rect` compiles
- use `HtmlImageElement` import directly to avoid unused import

## Testing
- `cargo +nightly fmt --all -- --check`
- `cargo check --all-features`
- `cargo check --target wasm32-unknown-unknown --all-features`
- `cargo test --all-features`
- `cargo clippy --all-features -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_683fb3dfacf4832a809b874c06fca307