### PR TITLE
Add inventory display and pickup

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -135,3 +135,29 @@ button:focus-visible {
   font-size: 12px;
   pointer-events: none;
 }
+
+#inventory-container {
+  display: flex;
+  gap: 4px;
+  background: #222;
+  padding: 4px;
+  border: 1px solid #666;
+  margin: 4px auto;
+  box-sizing: border-box;
+  justify-content: flex-start;
+  align-items: center;
+}
+
+.inventory-item {
+  width: 32px;
+  height: 32px;
+  border: 1px solid #555;
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- add inventory container UI and styling
- expose inventory info in interpreter and web interface
- implement pickupObject and addToInventory logic
- show inventory items in web UI
- test picking up objects updates inventory

## Testing
- `cargo +nightly fmt --all -- --check`
- `cargo check --all-features`
- `cargo check --target wasm32-unknown-unknown --all-features`
- `cargo test --all-features`
- `cargo clippy --all-features -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_683ff2e42a84832aa63019ea7df369b2