### PR TITLE
Enable inventory item interactions

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -562,6 +562,21 @@ impl WebInterface {
 					div.set_inner_html(&obj.name);
 				}
 				div.set_attribute("style", &style)?;
+
+				// Allow interacting with inventory objects
+				let self_clone = self.clone();
+				let interp_clone = interp.clone();
+				let id_clone = *id;
+				let context_closure = wasm_bindgen::closure::Closure::wrap(Box::new(move |e: web_sys::MouseEvent| {
+					e.prevent_default();
+					e.stop_propagation();
+					let mut verbs = interp_clone.verbs_for_object(id_clone);
+					verbs.retain(|v| v != "vPickUp");
+					let _ = self_clone.show_context_menu(id_clone, e.client_x(), e.client_y(), verbs, interp_clone.clone());
+				}) as Box<dyn FnMut(_)>);
+				div.add_event_listener_with_callback("click", context_closure.as_ref().unchecked_ref())?;
+				context_closure.forget();
+
 				self.inventory_container.append_child(&div)?;
 			}
 		}


### PR DESCRIPTION
## Summary
- allow clicking items in the inventory to open a verb menu
- filter out `vPickUp` when showing verbs for inventory objects

## Testing
- `cargo +nightly fmt --all -- --check`
- `cargo check --all-features`
- `cargo check --target wasm32-unknown-unknown --all-features`
- `cargo test --all-features`
- `cargo clippy --all-features -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_683ffa7b2f74832aa0e96b60c89e03a3