### PR TITLE
Fix inventory object hover names

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -555,6 +555,30 @@ impl WebInterface {
 				}
 				div.set_attribute("style", &style)?;
 
+				// Show object name when hovering
+				let name = obj.name.clone();
+				let self_clone = self.clone();
+				let mouse_enter = wasm_bindgen::closure::Closure::wrap(Box::new(move |e: web_sys::MouseEvent| {
+					let _ = self_clone.show_object_name(&name, e.client_x(), e.client_y());
+				}) as Box<dyn FnMut(_)>);
+				div.add_event_listener_with_callback("mouseenter", mouse_enter.as_ref().unchecked_ref())?;
+				mouse_enter.forget();
+
+				let name = obj.name.clone();
+				let self_clone = self.clone();
+				let mouse_move = wasm_bindgen::closure::Closure::wrap(Box::new(move |e: web_sys::MouseEvent| {
+					let _ = self_clone.show_object_name(&name, e.client_x(), e.client_y());
+				}) as Box<dyn FnMut(_)>);
+				div.add_event_listener_with_callback("mousemove", mouse_move.as_ref().unchecked_ref())?;
+				mouse_move.forget();
+
+				let self_clone = self.clone();
+				let leave = wasm_bindgen::closure::Closure::wrap(Box::new(move |_e: web_sys::MouseEvent| {
+					let _ = self_clone.hide_object_name();
+				}) as Box<dyn FnMut(_)>);
+				div.add_event_listener_with_callback("mouseleave", leave.as_ref().unchecked_ref())?;
+				leave.forget();
+
 				// Allow interacting with inventory objects
 				let self_clone = self.clone();
 				let interp_clone = interp.clone();


### PR DESCRIPTION
## Summary
- show inventory object names on hover so they match room objects

## Testing
- `cargo +nightly fmt --all -- --check`
- `cargo check --all-features`
- `cargo check --target wasm32-unknown-unknown --all-features`
- `cargo test --all-features`
- `cargo clippy --all-features -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_68400f37d748832aad3d712add023801