### PR TITLE
Enable inventory drag-and-use interactions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ thiserror = "2.0.12"
 wasm-bindgen-futures = "0.4"
 web-sys      = { version = "0.3", features = ["HtmlImageElement",
                                               "Element", "Document",
-                                              "Window", "MouseEvent", "Response", "console",
+                                              "Window", "MouseEvent", "DragEvent", "Response", "console",
                                               "DomRect"] }
 futures = "0.3.31"
 async-recursion = "1.1.1"

--- a/src/style.css
+++ b/src/style.css
@@ -136,6 +136,11 @@ button:focus-visible {
   pointer-events: none;
 }
 
+#use-hint {
+  font-size: 12px;
+  pointer-events: none;
+}
+
 #inventory-container {
   display: flex;
   gap: 4px;


### PR DESCRIPTION
## Summary
- allow dragging inventory items and dropping them on other objects
- show a temporary "Use X on Y" label while dragging over a valid target
- execute `vUse` verb when dropping between objects
- enable DragEvent feature in `web-sys`

## Testing
- `cargo +nightly fmt --all -- --check`
- `cargo check --all-features`
- `cargo check --target wasm32-unknown-unknown --all-features`
- `cargo test --all-features`
- `cargo clippy --all-features -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684016b8f79c832a8841cadb0c48a302