### PR TITLE
Fix empty verb menu

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -590,6 +590,12 @@ impl WebInterface {
 	}
 
 	fn show_context_menu(&self, obj_id: u32, x: i32, y: i32, verbs: Vec<String>, interp: Interpreter) -> Result<(), JsValue> {
+		if verbs.is_empty() {
+			if let Some(menu) = self.document.get_element_by_id("context-menu") {
+				menu.set_attribute("style", "display:none;")?;
+			}
+			return Ok(());
+		}
 		let menu = if let Some(existing) = self.document.get_element_by_id("context-menu") {
 			existing
 		} else {


### PR DESCRIPTION
## Summary
- avoid showing the context menu when an object has no verbs

## Testing
- `cargo +nightly fmt --all -- --check`
- `cargo check --all-features`
- `cargo check --target wasm32-unknown-unknown --all-features`
- `cargo test --all-features`
- `cargo clippy --all-features -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_6840d489a04c832a88c7a494bcf8cf95