### PR TITLE
Simplify expression parsing via grammar precedence

### DIFF
--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -32,12 +32,14 @@ while_stmt  =  { "while" ~ "(" ~ expr ~ ")" ~ block }
 
 expr        =  _{ assignment }
 assignment  =  { logical_or ~ ("=" ~ assignment)? }
-logical_or  =  { logical_and ~ ("||" ~ logical_and)* }
-logical_and =  { equality ~ ("&&" ~ equality)* }
-equality    =  { comparison ~ (eq_op ~ comparison)* }
-comparison  =  { term ~ (cmp_op ~ term)* }
-term        =  { factor ~ (add_op ~ factor)* }
-factor      =  { unary ~ (mul_op ~ unary)* }
+logical_or_op = { "||" }
+logical_and_op = { "&&" }
+logical_or  =  { logical_and ~ (logical_or_op ~ logical_or)? }
+logical_and =  { equality ~ (logical_and_op ~ logical_and)? }
+equality    =  { comparison ~ (eq_op ~ equality)? }
+comparison  =  { term ~ (cmp_op ~ comparison)? }
+term        =  { factor ~ (add_op ~ term)? }
+factor      =  { unary ~ (mul_op ~ factor)? }
 eq_op       = { "==" | "!=" }
 cmp_op      = { "<=" | ">=" | "<" | ">" }
 add_op      = { "+" | "-" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,18 +55,18 @@ fn parse_def_block(pair: Pair<Rule>) -> Result<Block, String> {
 
 fn parse_binary_expr<O, F>(pair: Pair<Rule>, map_op: fn(&str) -> O, make_expr: F) -> Expression
 where
-        F: Fn(Box<Expression>, O, Box<Expression>) -> Expression,
+	F: Fn(Box<Expression>, O, Box<Expression>) -> Expression,
 {
-        let mut inner = pair.into_inner();
-        let left = parse_expression(inner.next().unwrap());
-        if let Some(op_pair) = inner.next() {
-                let right_pair = inner.next().unwrap();
-                let op = map_op(op_pair.as_str());
-                let right_expr = parse_expression(right_pair);
-                make_expr(Box::new(left), op, Box::new(right_expr))
-        } else {
-                left
-        }
+	let mut inner = pair.into_inner();
+	let left = parse_expression(inner.next().unwrap());
+	if let Some(op_pair) = inner.next() {
+		let right_pair = inner.next().unwrap();
+		let op = map_op(op_pair.as_str());
+		let right_expr = parse_expression(right_pair);
+		make_expr(Box::new(left), op, Box::new(right_expr))
+	} else {
+		left
+	}
 }
 
 fn parse_room_block(pair: Pair<Rule>) -> Result<Block, String> {
@@ -172,16 +172,12 @@ fn parse_expression(pair: Pair<Rule>) -> Expression {
 				left
 			}
 		},
-                Rule::logical_or => parse_binary_expr(
-                        pair,
-                        |_| (), // operator has no enum, handled directly
-                        |l, _, r| Expression::LogicalOr(l, r),
-                ),
-                Rule::logical_and => parse_binary_expr(
-                        pair,
-                        |_| (),
-                        |l, _, r| Expression::LogicalAnd(l, r),
-                ),
+		Rule::logical_or => parse_binary_expr(
+			pair,
+			|_| (), // operator has no enum, handled directly
+			|l, _, r| Expression::LogicalOr(l, r),
+		),
+		Rule::logical_and => parse_binary_expr(pair, |_| (), |l, _, r| Expression::LogicalAnd(l, r)),
 		Rule::equality => parse_binary_expr(
 			pair,
 			|op| match op {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,17 +55,18 @@ fn parse_def_block(pair: Pair<Rule>) -> Result<Block, String> {
 
 fn parse_binary_expr<O, F>(pair: Pair<Rule>, map_op: fn(&str) -> O, make_expr: F) -> Expression
 where
-	F: Fn(Box<Expression>, O, Box<Expression>) -> Expression,
+        F: Fn(Box<Expression>, O, Box<Expression>) -> Expression,
 {
-	let mut inner = pair.into_inner();
-	let mut expr = parse_expression(inner.next().unwrap());
-	while let Some(op_pair) = inner.next() {
-		let right_pair = inner.next().unwrap();
-		let op = map_op(op_pair.as_str());
-		let right_expr = parse_expression(right_pair);
-		expr = make_expr(Box::new(expr), op, Box::new(right_expr));
-	}
-	expr
+        let mut inner = pair.into_inner();
+        let left = parse_expression(inner.next().unwrap());
+        if let Some(op_pair) = inner.next() {
+                let right_pair = inner.next().unwrap();
+                let op = map_op(op_pair.as_str());
+                let right_expr = parse_expression(right_pair);
+                make_expr(Box::new(left), op, Box::new(right_expr))
+        } else {
+                left
+        }
 }
 
 fn parse_room_block(pair: Pair<Rule>) -> Result<Block, String> {
@@ -171,28 +172,16 @@ fn parse_expression(pair: Pair<Rule>) -> Expression {
 				left
 			}
 		},
-		Rule::logical_or => {
-			let mut inner = pair.into_inner();
-			let mut expr = parse_expression(inner.next().unwrap());
-
-			// Each remaining pair is another logical_and expression to OR with
-			for right_pair in inner {
-				let right_expr = parse_expression(right_pair);
-				expr = Expression::LogicalOr(Box::new(expr), Box::new(right_expr));
-			}
-			expr
-		},
-		Rule::logical_and => {
-			let mut inner = pair.into_inner();
-			let mut expr = parse_expression(inner.next().unwrap());
-
-			// Each remaining pair is another equality expression to AND with
-			for right_pair in inner {
-				let right_expr = parse_expression(right_pair);
-				expr = Expression::LogicalAnd(Box::new(expr), Box::new(right_expr));
-			}
-			expr
-		},
+                Rule::logical_or => parse_binary_expr(
+                        pair,
+                        |_| (), // operator has no enum, handled directly
+                        |l, _, r| Expression::LogicalOr(l, r),
+                ),
+                Rule::logical_and => parse_binary_expr(
+                        pair,
+                        |_| (),
+                        |l, _, r| Expression::LogicalAnd(l, r),
+                ),
 		Rule::equality => parse_binary_expr(
 			pair,
 			|op| match op {


### PR DESCRIPTION
## Summary
- define operator tokens in `grammar.pest`
- make expression rules right‑recursive so precedence is handled by the grammar
- simplify `parse_binary_expr` and update expression parsing logic

## Testing
- `cargo +nightly fmt --all -- --check`
- `cargo check --all-features`
- `cargo check --target wasm32-unknown-unknown --all-features`
- `cargo test --all-features`
- `cargo clippy --all-features -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684172e939dc832aba62f759809fdeb0