### PR TITLE
Load script via URL hash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ wasm-bindgen-futures = "0.4"
 web-sys      = { version = "0.3", features = ["HtmlImageElement",
                                               "Element", "Document",
                                               "Window", "MouseEvent", "DragEvent", "Response", "console",
-                                              "DomRect"] }
+                                              "DomRect", "Location"] }
 futures = "0.3.31"
 async-recursion = "1.1.1"
 indexmap = "2.9.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -387,7 +387,12 @@ pub fn parse_str(input: &str) -> Result<Vec<TopLevel>> {
 
 
 pub async fn load_script_raw() -> Result<String, JsValue> {
-	let resp_value = JsFuture::from(window().fetch_with_str("/example.sc")).await?;
+	let window = window();
+	let location = window.location();
+	let hash = location.hash().unwrap_or_default();
+	let script = hash.strip_prefix('#').filter(|s| !s.is_empty()).unwrap_or("example.sc");
+	let url = format!("/{}", script);
+	let resp_value = JsFuture::from(window.fetch_with_str(&url)).await?;
 
 	let resp: Response = resp_value.dyn_into()?;
 	let text = JsFuture::from(resp.text()?).await?;


### PR DESCRIPTION
## Summary
- support specifying script file through URL hash
- enable `Location` in web-sys features

## Testing
- `cargo +nightly fmt --all -- --check`
- `cargo check --all-features`
- `cargo check --target wasm32-unknown-unknown --all-features`
- `cargo test --all-features`
- `cargo clippy --all-features -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684214ede52c832aacd398e0c4bcf4e1